### PR TITLE
Add BSP drivers sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,22 @@
 **STM32Cube** is an STMicroelectronics original initiative to ease the developers life by reducing efforts, time and cost.
 
 **STM32Cube** covers the overall STM32 products portfolio (MCU and MPU). It includes a comprehensive embedded software platform, delivered for each STM32 series.
-   * The CMSIS modules (core and device) corresponding to the ARM(tm) core implemented in this STM32 product
-   * The STM32 HAL-LL drivers : an abstraction drivers layer, the API ensuring maximized portability across the STM32 portfolio
-   * The BSP Drivers of each evaluation or demonstration board provided by this STM32 series
-   * A consistent set of middlewares components such as RTOS, USB, FatFS, Graphics, TCP/IP, BLE, STM32_TouchSensing_Library ...
-   * A full set of software projects (basic examples, applications or demonstrations) for each board provided by this STM32 series
+   * The CMSIS modules (core and device) corresponding to the ARM(tm) core implemented in this STM32 product.
+   * The STM32 HAL-LL drivers : an abstraction drivers layer, the API ensuring maximized portability across the STM32 portfolio.
+   * The BSP Drivers of each evaluation or demonstration board provided by this STM32 series.
+   * A consistent set of middlewares components such as RTOS, USB, FatFS, Graphics, TCP/IP, BLE, STM32_TouchSensing_Library...
+   * A full set of software projects (basic examples, applications or demonstrations) for each board provided by this STM32 series.
 
 GitHub is a new publication model for the STM32Cube MCU embedded software. Three models of publication are proposed:
    * The **MCU Package** : monolithic STM32Cube software modules, per STM32 MCU series (Drivers, Middlewares, Utilities, Examples Projects) in an unique repo. The usual name of a STM32MCU Package is **STM32Cubexx**, xx corresponding to the STM32 series). Please refer to the chapter **STM32Cube MCU Packages** below.
 
    * The **MCU components** : parts of the MCU Packages, proposed as individual repos, allowing the user to select and get only the required software functions. Please refer to the chapter **STM32Cube MCU Components** below.
 
-   * The **X-CUBE** : Expansion softwares, propose embedded software components that complement the functionalities of the STM32Cube 
-   
-   * A set of **MCU Utilities** : Various Utility features proposed in dedicated repos
-   
-Please note that a MPU offer is also proposed for the **STM32 MPU Products**. You can refer to the repo [STM32MPU_EmbSW_Overall_Offer](https://github.com/STMicroelectronics/STM32MPU_EmbSW_Overall_Offer)
+   * The **X-CUBE** : Expansion softwares, propose embedded software components that complement the functionalities of the STM32Cube.
+
+   * A set of **MCU Utilities** : Various Utility features proposed in dedicated repos.
+
+Please note that a MPU offer is also proposed for the **STM32 MPU Products**. You can refer to the repo [STM32MPU_EmbSW_Overall_Offer](https://github.com/STMicroelectronics/STM32MPU_EmbSW_Overall_Offer).
 
 
 ## Description
@@ -37,14 +37,15 @@ For general communication and support, you can use
    * [ST Support Center](https://my.st.com/ols#/ols/) for any defect
    * [ST Community Forum](https://community.st.com/stm32mcu) forum
 
-### Content 
+### Content
 
-   * [STM32Cube MCU Packages](https://github.com/STMicroelectronics/STM32Cube_MCU_Overall_Offer#stm32cube-mcu-packages)
-   * [STM32Cube CMSIS](https://github.com/STMicroelectronics/STM32Cube_MCU_Overall_Offer#stm32cube-cmsis)
-   * [STM32Cube HAL Drivers](https://github.com/STMicroelectronics/STM32Cube_MCU_Overall_Offer#stm32cube-hal-drivers)
-   * [STM32Cube MW Libraries](https://github.com/STMicroelectronics/STM32Cube_MCU_Overall_Offer#stm32cube-middleware-libraries)
-   * [STM32Cube X-CUBE](https://github.com/STMicroelectronics/STM32Cube_MCU_Overall_Offer#x-cube-expansion-softwares)
-   * [STM32Cube Utilities](https://github.com/STMicroelectronics/STM32Cube_MCU_Overall_Offer#stm32cube-utilities-and-miscellaneous-repos)
+   * [STM32Cube MCU Packages](README.md#stm32cube-mcu-packages)
+   * [STM32Cube CMSIS](README.md#stm32cube-cmsis)
+   * [STM32Cube HAL Drivers](README.md#stm32cube-hal-drivers)
+   * [STM32Cube BSP Drivers](README.md#stm32cube-bsp-drivers)
+   * [STM32Cube MW Libraries](README.md#stm32cube-middleware-libraries)
+   * [STM32Cube X-CUBE](README.md#x-cube-expansion-softwares)
+   * [STM32Cube Utilities](README.md#stm32cube-utilities-and-miscellaneous-repos)
 
 ### STM32Cube MCU Packages
 
@@ -70,7 +71,7 @@ STM32Cube MCU Packages | Description
 
 As mentioned above, the STM32Cube Components is an alternative delivery model to the STM32 Packages. In this case, each module is delivered as individual repos, allowing the customer to select and download only the pertinent features.
    * Components available today : CMSIS - HAL/LL - Base MW (USB, FatFS, FrreRTOS, LwIP)
-   * Components upcoming : Other MW - BSP - Utilities 
+   * Components upcoming : Other MW - BSP - Utilities
 
 In each module README file you will find the cross compatibility information. When all modules will be available a set of new Manifest files (series by series) will be proposed to drive the user.
 
@@ -100,7 +101,7 @@ STM32Cube CMSIS Devices | Description
 
 #### STM32Cube HAL Drivers
 
-The **HAL Drivers** MCU Components propose the HAL and LL Drivers modules controlling all the HW IPs embedded in the STM32 product
+The **HAL Drivers** MCU Components propose the HAL and LL Drivers modules controlling all the HW IPs embedded in the STM32 products.
 
 * HAL Drivers:
   * A set of portable abstraction APIs offering high level services, built around standalone processes. The HAL drivers are functionalities oriented, example: for the Timer peripheral, the APIs could be split into several categories following the functions offered by the IPs (Basic timer, capture, PWM …etc.) for a communication IP: an initialisation function, eventually a configuration function and data transfer services (polling, interruption or DMA based)
@@ -131,6 +132,139 @@ STM32Cube HAL Drivers | Description
 [stm32l5xx_hal_driver](https://github.com/STMicroelectronics/stm32l5xx_hal_driver) | The STM32L5 HAL-LL Drivers
 [stm32wbxx_hal_driver](https://github.com/STMicroelectronics/stm32wbxx_hal_driver) | The STM32WB HAL-LL Drivers
 [stm32wlxx_hal_driver](https://github.com/STMicroelectronics/stm32wlxx_hal_driver) | The STM32WL HAL-LL Drivers
+
+#### STM32Cube BSP Drivers
+
+The **BSP Drivers** MCU Components propose the BSP Drivers modules, which are constituted from the:
+   * [STM32Cube BSP Boards Drivers](README.md#stm32cube-bsp-boards-drivers), **based on the HAL drivers**, and providing a set of high level APIs allowing a quick access to the boards’ services (**e.g.**, audio, graphics, access to external memories).
+   * [STM32Cube BSP Components Drivers](README.md#stm32cube-bsp-components-drivers) providing a set of high level APIs allowing a quick access to the (**e.g.**, audio codecs, LCD drivers, SD cards, MEMS). The **link** between these external components and the HAL drivers (**e.g.**, a SD card and the `OSPI`/`QSPI` HAL driver) is done within the **BSP Boards** drivers.
+
+##### STM32Cube BSP Boards Drivers:
+
+STM32CubeF4 BSP Boards Drivers | Description
+------------------------------ | -----------
+[stm32f4xx-nucleo-144](https://github.com/STMicroelectronics/stm32f4xx-nucleo-144) | The STM32F4xx Nucleo 144 BSP Board Driver
+[stm32f4xx-nucleo](https://github.com/STMicroelectronics/stm32f4xx-nucleo) | The STM32F4xx Nucleo BSP Board Driver
+[stm324xg-eval](https://github.com/STMicroelectronics/stm324xg-eval) | The STM324xG EVAL BSP Board Driver
+[stm32469i-eval](https://github.com/STMicroelectronics/stm32469i-eval) | The STM32469I EVAL BSP Board Driver
+[stm32469i-discovery](https://github.com/STMicroelectronics/stm32469i-discovery) | The STM32469I Discovery BSP Board Driver
+[stm32f429i-discovery](https://github.com/STMicroelectronics/stm32f429i-discovery) | The STM32F429I Discovery BSP Board Driver
+[stm32f401-discovery](https://github.com/STMicroelectronics/stm32f401-discovery) | The STM32F401 Discovery BSP Board Driver
+[stm32446e-eval](https://github.com/STMicroelectronics/stm32446e-eval) | The STM32446E EVAL BSP Board Driver
+[stm32f411e-discovery](https://github.com/STMicroelectronics/stm32f411e-discovery) | The STM32F411E Discovery BSP Board Driver
+[stm32412g-discovery](https://github.com/STMicroelectronics/stm32412g-discovery) | The STM32412G Discovery BSP Board Driver
+[stm32f413h-discovery](https://github.com/STMicroelectronics/stm32f413h-discovery) | The STM32F413H Discovery BSP Board Driver
+[stm32f4-discovery](https://github.com/STMicroelectronics/stm32f4-discovery) | The STM32F4 Discovery BSP Board Driver
+[stm324x9i-eval](https://github.com/STMicroelectronics/stm324x9i-eval) | The STM324x9I EVAL BSP Board Driver
+
+##### STM32Cube BSP Components Drivers:
+
+STM32Cube BSP Audio Components Drivers | Description
+-------------------------------------- | -----------
+[stm32-adv7533](https://github.com/STMicroelectronics/stm32-adv7533) | The ADV7533 BSP Component Driver
+[stm32-ak4343](https://github.com/STMicroelectronics/stm32-ak4343) | The AK4343 BSP Component Driver
+[stm32-cs42l51](https://github.com/STMicroelectronics/stm32-cs42l51) | The CS42L51 BSP Component Driver
+[stm32-cs42l52](https://github.com/STMicroelectronics/stm32-cs42l52) | The CS42L52 BSP Component Driver
+[stm32-cs43l22](https://github.com/STMicroelectronics/stm32-cs43l22) | The CS43L22 BSP Component Driver
+[stm32-wm8994](https://github.com/STMicroelectronics/stm32-wm8994) | The WM8994 BSP Component Driver
+
+STM32Cube BSP Camera Components Drivers | Description
+--------------------------------------- | -----------
+[stm32-ov2640](https://github.com/STMicroelectronics/stm32-ov2640) | The OV2640 BSP Component Driver
+[stm32-ov5640](https://github.com/STMicroelectronics/stm32-ov5640) | The OV5640 BSP Component Driver
+[stm32-ov9655](https://github.com/STMicroelectronics/stm32-ov9655) | The OV9655 BSP Component Driver
+[stm32-s5k5cag](https://github.com/STMicroelectronics/stm32-s5k5cag) | The S5K5CAG BSP Component Driver
+
+STM32Cube BSP IO Expander Components Drivers | Description
+-------------------------------------------- | -----------
+[stm32-mfxstm32l152](https://github.com/STMicroelectronics/stm32-mfxstm32l152) | The MFXSTM32L152 BSP Component Driver
+[stm32-stmpe1600](https://github.com/STMicroelectronics/stm32-stmpe1600) | The STMPE1600 BSP Component Driver
+[stm32-stmpe811](https://github.com/STMicroelectronics/stm32-stmpe811) | The STMPE811 BSP Component Driver
+
+STM32Cube BSP LCD Components Drivers | Description
+------------------------------------ | -----------
+[stm32-ampire480272](https://github.com/STMicroelectronics/stm32-ampire480272) | The AMPIRE480272 BSP Component Driver
+[stm32-ampire640480](https://github.com/STMicroelectronics/stm32-ampire640480) | The AMPIRE640480 BSP Component Driver
+[stm32-hx8347d](https://github.com/STMicroelectronics/stm32-hx8347d) | The HX8347D BSP Component Driver
+[stm32-hx8347g](https://github.com/STMicroelectronics/stm32-hx8347g) | The HX8347G BSP Component Driver
+[stm32-hx8347i](https://github.com/STMicroelectronics/stm32-hx8347i) | The HX8347I BSP Component Driver
+[stm32-ili9320](https://github.com/STMicroelectronics/stm32-ili9320) | The ILI9320 BSP Component Driver
+[stm32-ili9325](https://github.com/STMicroelectronics/stm32-ili9325) | The ILI9325 BSP Component Driver
+[stm32-ili9328](https://github.com/STMicroelectronics/stm32-ili9328) | The ILI9328 BSP Component Driver
+[stm32-ili9341](https://github.com/STMicroelectronics/stm32-ili9341) | The ILI9341 BSP Component Driver
+[stm32-ls016b8uy](https://github.com/STMicroelectronics/stm32-ls016b8uy) | The LS016B8UY BSP Component Driver
+[stm32-nt35510](https://github.com/STMicroelectronics/stm32-nt35510) | The NT35510 BSP Component Driver
+[stm32-otm8009a](https://github.com/STMicroelectronics/stm32-otm8009a) | The OTM8009A BSP Component Driver
+[stm32-rk043fn48h](https://github.com/STMicroelectronics/stm32-rk043fn48h) | The RK043FN48H BSP Component Driver
+[stm32-rk070er9427](https://github.com/STMicroelectronics/stm32-rk070er9427) | The RK070ER9427 BSP Component Driver
+[stm32-spfd5408](https://github.com/STMicroelectronics/stm32-spfd5408) | The SPFD5408 BSP Component Driver
+[stm32-ssd1315](https://github.com/STMicroelectronics/stm32-ssd1315) | The SSD1315 BSP Component Driver
+[stm32-st7735](https://github.com/STMicroelectronics/stm32-st7735) | The ST7735 BSP Component Driver
+[stm32-st7789h2](https://github.com/STMicroelectronics/stm32-st7789h2) | The ST7789H2 BSP Component Driver
+
+STM32Cube BSP MEMS Components Drivers | Description
+------------------------------------- | -----------
+[stm32-hts221](https://github.com/STMicroelectronics/stm32-hts221) | The HTS221 BSP Component Driver
+[stm32-i3g4250d](https://github.com/STMicroelectronics/stm32-i3g4250d) | The I3G4250D BSP Component Driver
+[stm32-l3gd20](https://github.com/STMicroelectronics/stm32-l3gd20) | The L3GD20 BSP Component Driver
+[stm32-lan8742](https://github.com/STMicroelectronics/stm32-lan8742) | The LAN8742 BSP Component Driver
+[stm32-lis302dl](https://github.com/STMicroelectronics/stm32-lis302dl) | The LIS302DL BSP Component Driver
+[stm32-lis3dsh](https://github.com/STMicroelectronics/stm32-lis3dsh) | The LIS3DSH BSP Component Driver
+[stm32-lis3mdl](https://github.com/STMicroelectronics/stm32-lis3mdl) | The LIS3MDL BSP Component Driver
+[stm32-lps22hb](https://github.com/STMicroelectronics/stm32-lps22hb) | The LPS22HB BSP Component Driver
+[stm32-lsm303agr](https://github.com/STMicroelectronics/stm32-lsm303agr) | The LSM303AGR BSP Component Driver
+[stm32-lsm303c](https://github.com/STMicroelectronics/stm32-lsm303c) | The LSM303C BSP Component Driver
+[stm32-lsm303dlhc](https://github.com/STMicroelectronics/stm32-lsm303dlhc) | The LSM303DLHC BSP Component Driver
+[stm32-lsm6dsl](https://github.com/STMicroelectronics/stm32-lsm6dsl) | The LSM6DSL BSP Component Driver
+[stm32-s70kl1281](https://github.com/STMicroelectronics/stm32-s70kl1281) | The S70KL1281 BSP Component Driver
+
+STM32Cube BSP QSPI/OSPI Components Drivers | Description
+------------------------------------------ | -----------
+[stm32-iss66wvh8m8](https://github.com/STMicroelectronics/stm32-iss66wvh8m8) | The ISS66WVH8M8 BSP Component Driver
+[stm32-mt25ql512abb](https://github.com/STMicroelectronics/stm32-mt25ql512abb) | The MT25QL512ABB BSP Component Driver
+[stm32-mt25tl01g](https://github.com/STMicroelectronics/stm32-mt25tl01g) | The MT25TL01G BSP Component Driver
+[stm32-mx25l512](https://github.com/STMicroelectronics/stm32-mx25l512) | The MX25L512 BSP Component Driver
+[stm32-mx25lm51245g](https://github.com/STMicroelectronics/stm32-mx25lm51245g) | The MX25LM51245G BSP Component Driver
+[stm32-mx25r6435f](https://github.com/STMicroelectronics/stm32-mx25r6435f) | The MX25R6435F BSP Component Driver
+[stm32-n25q128a](https://github.com/STMicroelectronics/stm32-n25q128a) | The N25Q128A BSP Component Driver
+[stm32-n25q256a](https://github.com/STMicroelectronics/stm32-n25q256a) | The N25Q256A BSP Component Driver
+[stm32-n25q512a](https://github.com/STMicroelectronics/stm32-n25q512a) | The N25Q512A BSP Component Driver
+[stm32-s25fl512s](https://github.com/STMicroelectronics/stm32-s25fl512s) | The S25FL512S BSP Component Driver
+[stm32-w25q80ew](https://github.com/STMicroelectronics/stm32-w25q80ew) | The W25Q80EW BSP Component Driver
+
+STM32Cube BSP SDRAM Components Drivers | Description
+-------------------------------------- | -----------
+[stm32-is42s16800j](https://github.com/STMicroelectronics/stm32-is42s16800j) | The IS42S16800J BSP Component Driver
+[stm32-is42s32800g](https://github.com/STMicroelectronics/stm32-is42s32800g) | The IS42S32800G BSP Component Driver
+[stm32-is42s32800j](https://github.com/STMicroelectronics/stm32-is42s32800j) | The IS42S32800J BSP Component Driver
+[stm32-mt48lc4m32b2](https://github.com/STMicroelectronics/stm32-mt48lc4m32b2) | The MT48LC4M32B2 BSP Component Driver
+
+STM32Cube BSP Temperature Sensor Components Drivers | Description
+--------------------------------------------------- | -----------
+[stm32-stlm75](https://github.com/STMicroelectronics/stm32-stlm75) | The STLM75 BSP Component Driver
+[stm32-stts751](https://github.com/STMicroelectronics/stm32-stts751) | The STTS751 BSP Component Driver
+
+STM32Cube BSP Touch Screen Components Drivers | Description
+-------------------------------------- | -----------
+[stm32-cy8c4014lqi](https://github.com/STMicroelectronics/stm32-cy8c4014lqi) | The CY8C4014LQI BSP Component Driver
+[stm32-exc7200](https://github.com/STMicroelectronics/stm32-exc7200) | The EXC7200 BSP Component Driver
+[stm32-ft3x67](https://github.com/STMicroelectronics/stm32-ft3x67) | The FT3X67 BSP Component Driver
+[stm32-ft6x06](https://github.com/STMicroelectronics/stm32-ft6x06) | The FT6X06 BSP Component Driver
+[stm32-ft5336](https://github.com/STMicroelectronics/stm32-ft5336) | The FT5336 BSP Component Driver
+[stm32-ts3510](https://github.com/STMicroelectronics/stm32-ts3510) | The TS3510 BSP Component Driver
+
+STM32Cube BSP USB-C Components Drivers | Description
+-------------------------------------- | -----------
+[stm32-cbtl08gp053](https://github.com/STMicroelectronics/stm32-cbtl08gp053) | The CBTL08GP053 BSP Component Driver
+[stm32-sn65dp141](https://github.com/STMicroelectronics/stm32-sn65dp141) | The SN65DP141 BSP Component Driver
+[stm32-tusb546](https://github.com/STMicroelectronics/stm32-tusb546) | The TUSB546 BSP Component Driver
+
+STM32Cube BSP miscellaneous Components Drivers | Description
+---------------------------------------------- | -----------
+[stm32-gde021a1](https://github.com/STMicroelectronics/stm32-gde021a1) | The GDE021A1 BSP Component Driver
+[stm32-m24lr64](https://github.com/STMicroelectronics/stm32-m24lr64) | The M24LR64 BSP Component Driver
+[stm32-m24sr](https://github.com/STMicroelectronics/stm32-m24sr) | The M24SR BSP Component Driver
+[stm32-ina230](https://github.com/STMicroelectronics/stm32-ina230) | The INA230 BSP Component Driver
 
 #### STM32Cube Middleware Libraries
 
@@ -180,5 +314,5 @@ STM32Cube X-CUBE | Description
 STM32Cube Utilities | Description
 ------------------- | -----------
 [stm32-external-loader](https://github.com/STMicroelectronics/stm32-external-loader) | Flashloaders source code of external memories embedded in the STM32 HW boards.
-[stm32ai](https://github.com/STMicroelectronics/stm32ai) | git repo for the open source AI offer in STM32 products. 
+[stm32ai](https://github.com/STMicroelectronics/stm32ai) | git repo for the open source AI offer in STM32 products.
 [STM32_open_pin_data](https://github.com/STMicroelectronics/STM32_open_pin_data) | This repo provides all the information required for the pin and board configuration of products based on STM32 MCU.


### PR DESCRIPTION
Add sections listing the different repositories of BSP Boards drivers and BSP Components drivers already published on the [STMicroelectronics](https://github.com/STMicroelectronics).